### PR TITLE
#49 Fix Subscription update error

### DIFF
--- a/client/Pages/SubscriptionCreate/Models.elm
+++ b/client/Pages/SubscriptionCreate/Models.elm
@@ -7,7 +7,9 @@ import Helpers.AccessEditor as AccessEditor
 import Helpers.Forms exposing (..)
 import Helpers.Store exposing (ErrorMessage, Status(..))
 import Http
+import Json.Encode
 import MultiSearch.Models
+import Stores.Cursor exposing (subscriptionCursorEncoder)
 import Stores.Subscription
 import Stores.SubscriptionCursors
 
@@ -94,6 +96,12 @@ copyValues subscription =
     [ ( FieldConsumerGroup, subscription.consumer_group )
     , ( FieldOwningApplication, subscription.owning_application )
     , ( FieldReadFrom, subscription.read_from )
+    , ( FieldCursors
+      , subscription.initial_cursors
+            |> Maybe.withDefault []
+            |> Json.Encode.list subscriptionCursorEncoder
+            |> Json.Encode.encode 0
+      )
     , ( FieldEventTypes, subscription.event_types |> String.join "\n" )
     ]
         |> toValuesDict

--- a/client/Stores/Subscription.elm
+++ b/client/Stores/Subscription.elm
@@ -9,6 +9,7 @@ import Http
 import Json.Decode exposing (Decoder, at, list, map, maybe, nullable, string, succeed)
 import Json.Decode.Pipeline exposing (optional, required)
 import Stores.Authorization exposing (Authorization)
+import Stores.Cursor exposing (SubscriptionCursor, subscriptionCursorDecoder)
 import User.Commands exposing (logoutIfExpired)
 
 
@@ -20,6 +21,7 @@ type alias Subscription =
     , created_at : String
     , -- enum "begin", "end"
       read_from : String
+    , initial_cursors : Maybe (List SubscriptionCursor)
     , authorization : Maybe Authorization
     }
 
@@ -126,4 +128,5 @@ memberDecoder =
         |> optional "consumer_group" string "default"
         |> required "created_at" string
         |> optional "read_from" string "end"
+        |> optional "initial_cursors" (nullable (list subscriptionCursorDecoder)) Nothing
         |> optional "authorization" (nullable Stores.Authorization.collectionDecoder) Nothing

--- a/client/Stores/Subscription.elm
+++ b/client/Stores/Subscription.elm
@@ -19,7 +19,7 @@ type alias Subscription =
     , event_types : List String
     , consumer_group : String
     , created_at : String
-    , -- enum "begin", "end"
+    , -- enum "begin", "end", "cursors"
       read_from : String
     , initial_cursors : Maybe (List SubscriptionCursor)
     , authorization : Maybe Authorization


### PR DESCRIPTION
Nakadi does now allow to change or omit "initial_cursors" field, so in case when the subscription was created with initial cursors the update(PUT) also requires this field. It was never needed in UI before so encoder/decoder for  "initial_cursors" was missing.