### PR TITLE
#72 Fix Payload Too Large error

### DIFF
--- a/server/App.js
+++ b/server/App.js
@@ -31,7 +31,7 @@ module.exports = function App(config) {
     .get('/health', getHealth)
     .use(logger.init)
     .use(sessions(config.cookie))
-    .use(bodyParser.json())
+    .use(bodyParser.json({limit: '50mb'}))
     .use(auth(config.auth, config.settings))
     .use(analytics(config.analytics, logger))
     .use('/api/logs', authentication, logsApi(config.logsApi))


### PR DESCRIPTION
Fix `Payload Too Large` error by setting the limit to match Nakadi limit https://nakadi-faq.docs.zalando.net/#what-is-the-maximum-batch-size-nakadi-could-send-out