### PR TITLE
Remove checkbox for admins for all

### DIFF
--- a/client/Helpers/AccessEditor.elm
+++ b/client/Helpers/AccessEditor.elm
@@ -445,7 +445,7 @@ rowWrite config record =
           else
             none
         -- If record key not of type all but permission is alreay set, show checkbox for admin
-        , if not (record.key == All && not (hasPermission Admin record)) then
+        , if record.key /= All || (record|>hasPermission Admin) then
             checkboxWrite Admin record
           else
             none

--- a/client/Helpers/AccessEditor.elm
+++ b/client/Helpers/AccessEditor.elm
@@ -444,9 +444,11 @@ rowWrite config record =
 
           else
             none
+
         -- If record key not of type all but permission is alreay set, show checkbox for admin
-        , if record.key /= All || (record|>hasPermission Admin) then
+        , if record.key /= All || (record |> hasPermission Admin) then
             checkboxWrite Admin record
+
           else
             none
         , case record.key of

--- a/client/Helpers/AccessEditor.elm
+++ b/client/Helpers/AccessEditor.elm
@@ -444,7 +444,11 @@ rowWrite config record =
 
           else
             none
-        , checkboxWrite Admin record
+        -- If record key not of type all but permission is alreay set, show checkbox for admin
+        , if not (record.key == All && not (hasPermission Admin record)) then
+            checkboxWrite Admin record
+          else
+            none
         , case record.key of
             All ->
                 none

--- a/client/Pages/EventTypeDetails/Help.elm
+++ b/client/Pages/EventTypeDetails/Help.elm
@@ -502,8 +502,7 @@ authorization =
     , newline
     , text "An attribute for authorization. This object includes a data type, which represents the type of the attribute "
     , text "attribute (which data types are allowed depends on which authorization plugin is deployed, and how it is "
-    , text "configured), and a value. A wildcard can be represented with data type '*', and value '*'. It means that all "
-    , text "authenticated users are allowed to perform an operation."
+    , text "configured), and a value. Wildcards are not allowed for admins of event types and subscriptions."
     , newline
     , newline
     , bold "Key: "


### PR DESCRIPTION
Remove wildcard admin checkbox. Also, if there is already `admin` with `*` there for an event type, the checkbox is still visible. 