### PR TITLE
Add support for event_owner_selector

### DIFF
--- a/client/Pages/EventTypeCreate/Models.elm
+++ b/client/Pages/EventTypeCreate/Models.elm
@@ -13,8 +13,8 @@ import Stores.EventType
         , categories
         , cleanupPolicies
         , compatibilityModes
-        , partitionStrategies
         , emptyEventOwnerSelector
+        , partitionStrategies
         )
 import Stores.Partition
 
@@ -127,11 +127,10 @@ loadValues eventType =
                 |> Basics.ceiling
                 |> Basics.clamp 2 4
                 |> String.fromInt
-        
+
         ownerField =
             eventType.event_owner_selector
                 |> Maybe.withDefault emptyEventOwnerSelector
-        
     in
     defaultValues
         |> setValue FieldName eventType.name

--- a/client/Pages/EventTypeCreate/Models.elm
+++ b/client/Pages/EventTypeCreate/Models.elm
@@ -38,6 +38,9 @@ type Field
     | FieldSchema
     | FieldEnvelope
     | FieldAudience
+    | FieldEventOwnerSelectorType
+    | FieldEventOwnerSelectorName
+    | FieldEventOwnerSelectorValue
     | FieldCleanupPolicy
     | FieldSql
     | FieldPartitionCompactionKeyField
@@ -100,6 +103,9 @@ defaultValues =
     , ( FieldEnvelope, boolToString True )
     , ( FieldCompatibilityMode, compatibilityModes.forward )
     , ( FieldAudience, "" )
+    , ( FieldEventOwnerSelectorType, "" )
+    , ( FieldEventOwnerSelectorName, "" )
+    , ( FieldEventOwnerSelectorValue, "" )
     , ( FieldCleanupPolicy, cleanupPolicies.delete )
     , ( FieldPartitionCompactionKeyField, emptyString )
     ]

--- a/client/Pages/EventTypeCreate/Models.elm
+++ b/client/Pages/EventTypeCreate/Models.elm
@@ -14,6 +14,7 @@ import Stores.EventType
         , cleanupPolicies
         , compatibilityModes
         , partitionStrategies
+        , emptyEventOwnerSelector
         )
 import Stores.Partition
 
@@ -126,6 +127,11 @@ loadValues eventType =
                 |> Basics.ceiling
                 |> Basics.clamp 2 4
                 |> String.fromInt
+        
+        ownerField =
+            eventType.event_owner_selector
+                |> Maybe.withDefault emptyEventOwnerSelector
+        
     in
     defaultValues
         |> setValue FieldName eventType.name
@@ -138,6 +144,9 @@ loadValues eventType =
         |> setValue FieldSchema eventType.schema.schema
         |> setValue FieldRetentionTime retentionTime
         |> maybeSetValue FieldAudience eventType.audience
+        |> setValue FieldEventOwnerSelectorType ownerField.type_
+        |> setValue FieldEventOwnerSelectorName ownerField.name
+        |> setValue FieldEventOwnerSelectorValue ownerField.value
         |> setValue FieldCleanupPolicy eventType.cleanup_policy
 
 

--- a/client/Pages/EventTypeCreate/Update.elm
+++ b/client/Pages/EventTypeCreate/Update.elm
@@ -372,9 +372,30 @@ submitCreate model =
                 |> String.trim
                 |> Json.string
 
+        isEmptyString field =
+            model.values
+                |> getValue field
+                |> String.trim
+                |> String.isEmpty
+
         auth =
             AccessEditor.unflatten model.accessEditor.authorization
                 |> Stores.Authorization.encoder
+
+        event_owner_selector =
+            if isEmptyString FieldEventOwnerSelectorName && 
+                isEmptyString FieldEventOwnerSelectorValue && 
+                    isEmptyString FieldEventOwnerSelectorType then
+                []
+
+            else
+                [ ( "event_owner_selector", Json.object
+                    [ ( "type", asString FieldEventOwnerSelectorType )
+                    , ( "name", asString FieldEventOwnerSelectorName )
+                    , ( "value", asString FieldEventOwnerSelectorValue )
+                    ]
+                  )
+                ]
 
         fields =
             [ ( "name", asString FieldName )
@@ -419,7 +440,7 @@ submitCreate model =
                 ]
 
         body =
-            Json.object (List.concat [ fields, enrichment ])
+            Json.object (List.concat [ fields, enrichment, event_owner_selector ])
     in
     post body
 
@@ -456,10 +477,31 @@ submitUpdate model =
                 |> getValue field
                 |> String.trim
                 |> Json.string
+        
+        isEmptyString field =
+            model.values
+                |> getValue field
+                |> String.trim
+                |> String.isEmpty
 
         auth =
             AccessEditor.unflatten model.accessEditor.authorization
                 |> Stores.Authorization.encoder
+
+        event_owner_selector =
+            if isEmptyString FieldEventOwnerSelectorName && 
+                isEmptyString FieldEventOwnerSelectorValue && 
+                    isEmptyString FieldEventOwnerSelectorType then
+                []
+
+            else
+                [ ( "event_owner_selector", Json.object
+                    [ ( "type", asString FieldEventOwnerSelectorType )
+                    , ( "name", asString FieldEventOwnerSelectorName )
+                    , ( "value", asString FieldEventOwnerSelectorValue )
+                    ]
+                  )
+                ]
 
         fields =
             [ ( "name", asString FieldName )
@@ -496,7 +538,7 @@ submitUpdate model =
                 ]
 
         body =
-            Json.object (List.concat [ fields, enrichment ])
+            Json.object (List.concat [ fields, enrichment, event_owner_selector ])
     in
     put body (getValue FieldName model.values)
 

--- a/client/Pages/EventTypeCreate/Update.elm
+++ b/client/Pages/EventTypeCreate/Update.elm
@@ -383,17 +383,20 @@ submitCreate model =
                 |> Stores.Authorization.encoder
 
         event_owner_selector =
-            if isEmptyString FieldEventOwnerSelectorName && 
-                isEmptyString FieldEventOwnerSelectorValue && 
-                    isEmptyString FieldEventOwnerSelectorType then
+            if
+                isEmptyString FieldEventOwnerSelectorName
+                    && isEmptyString FieldEventOwnerSelectorValue
+                    && isEmptyString FieldEventOwnerSelectorType
+            then
                 []
 
             else
-                [ ( "event_owner_selector", Json.object
-                    [ ( "type", asString FieldEventOwnerSelectorType )
-                    , ( "name", asString FieldEventOwnerSelectorName )
-                    , ( "value", asString FieldEventOwnerSelectorValue )
-                    ]
+                [ ( "event_owner_selector"
+                  , Json.object
+                        [ ( "type", asString FieldEventOwnerSelectorType )
+                        , ( "name", asString FieldEventOwnerSelectorName )
+                        , ( "value", asString FieldEventOwnerSelectorValue )
+                        ]
                   )
                 ]
 
@@ -477,7 +480,7 @@ submitUpdate model =
                 |> getValue field
                 |> String.trim
                 |> Json.string
-        
+
         isEmptyString field =
             model.values
                 |> getValue field
@@ -489,17 +492,20 @@ submitUpdate model =
                 |> Stores.Authorization.encoder
 
         event_owner_selector =
-            if isEmptyString FieldEventOwnerSelectorName && 
-                isEmptyString FieldEventOwnerSelectorValue && 
-                    isEmptyString FieldEventOwnerSelectorType then
+            if
+                isEmptyString FieldEventOwnerSelectorName
+                    && isEmptyString FieldEventOwnerSelectorValue
+                    && isEmptyString FieldEventOwnerSelectorType
+            then
                 []
 
             else
-                [ ( "event_owner_selector", Json.object
-                    [ ( "type", asString FieldEventOwnerSelectorType )
-                    , ( "name", asString FieldEventOwnerSelectorName )
-                    , ( "value", asString FieldEventOwnerSelectorValue )
-                    ]
+                [ ( "event_owner_selector"
+                  , Json.object
+                        [ ( "type", asString FieldEventOwnerSelectorType )
+                        , ( "name", asString FieldEventOwnerSelectorName )
+                        , ( "value", asString FieldEventOwnerSelectorValue )
+                        ]
                   )
                 ]
 

--- a/client/Pages/EventTypeCreate/View.elm
+++ b/client/Pages/EventTypeCreate/View.elm
@@ -26,6 +26,7 @@ import Stores.EventType
         , cleanupPolicies
         , compatibilityModes
         , partitionStrategies
+        , allOwnerSelectorTypes
         )
 
 
@@ -264,6 +265,41 @@ viewForm model setup =
                 Required
                 Enabled
                 ("" :: allAudiences)
+            , div [ class "dc-row form-create__input-row" ]
+                [ selectInput formModel
+                    FieldEventOwnerSelectorType
+                    OnInput
+                    "Event Owner Selector Type"
+                    ""
+                    Help.eventOwnerSelector
+                    Optional
+                    Enabled
+                    ("" :: allOwnerSelectorTypes)
+                , div
+                    [ class "dc-column" ]
+                    [textInput formModel
+                        FieldEventOwnerSelectorName
+                        OnInput
+                        "Event Owner Selector Name"
+                        "Example: retailer_id"
+                        ""
+                        Help.eventOwnerSelector
+                        Optional
+                        Enabled
+                    ]
+                , div
+                    [ class "dc-column" ]
+                    [textInput formModel
+                        FieldEventOwnerSelectorValue
+                        OnInput
+                        "Event Owner Selector Value"
+                        "Example: security.owners"
+                        ""
+                        Help.eventOwnerSelector
+                        Optional
+                        Enabled
+                    ]
+                ]
             , selectInput formModel
                 FieldCleanupPolicy
                 OnInput

--- a/client/Pages/EventTypeCreate/View.elm
+++ b/client/Pages/EventTypeCreate/View.elm
@@ -171,7 +171,6 @@ viewForm model setup =
 
         appsInfoUrl =
             model.userStore.user.settings.appsInfoUrl
-
         usersInfoUrl =
             model.userStore.user.settings.usersInfoUrl
 

--- a/client/Pages/EventTypeCreate/View.elm
+++ b/client/Pages/EventTypeCreate/View.elm
@@ -22,11 +22,11 @@ import Stores.EventType
         , allCategories
         , allCleanupPolicies
         , allModes
+        , allOwnerSelectorTypes
         , categories
         , cleanupPolicies
         , compatibilityModes
         , partitionStrategies
-        , allOwnerSelectorTypes
         )
 
 
@@ -172,6 +172,7 @@ viewForm model setup =
 
         appsInfoUrl =
             model.userStore.user.settings.appsInfoUrl
+
         usersInfoUrl =
             model.userStore.user.settings.usersInfoUrl
 
@@ -277,7 +278,7 @@ viewForm model setup =
                     ("" :: allOwnerSelectorTypes)
                 , div
                     [ class "dc-column" ]
-                    [textInput formModel
+                    [ textInput formModel
                         FieldEventOwnerSelectorName
                         OnInput
                         "Event Owner Selector Name"
@@ -289,7 +290,7 @@ viewForm model setup =
                     ]
                 , div
                     [ class "dc-column" ]
-                    [textInput formModel
+                    [ textInput formModel
                         FieldEventOwnerSelectorValue
                         OnInput
                         "Event Owner Selector Value"

--- a/client/Pages/EventTypeDetails/Help.elm
+++ b/client/Pages/EventTypeDetails/Help.elm
@@ -1,4 +1,4 @@
-module Pages.EventTypeDetails.Help exposing (audience, authorization, category, cleanupPolicy, cleanupPolicyCompact, compatibilityMode, consumers, consumingQueries, createdAt, defaultStatistic, enrichmentStrategies, envelope, eventType, options, orderingKeyFields, owningApplication, partitionCompactionKeyField, partitionKeyFields, partitionStrategy, partitions, publishers, schema, subscription, updatedAt)
+module Pages.EventTypeDetails.Help exposing (audience, authorization, category, cleanupPolicy, cleanupPolicyCompact, compatibilityMode, consumers, consumingQueries, createdAt, defaultStatistic, enrichmentStrategies, envelope, eventType, options, orderingKeyFields, owningApplication, partitionCompactionKeyField, partitionKeyFields, partitionStrategy, partitions, publishers, schema, subscription, updatedAt, eventOwnerSelector)
 
 import Config exposing (appPreffix)
 import Helpers.UI exposing (..)
@@ -414,34 +414,38 @@ audience =
     ]
 
 
-eventAuthField : List (Html msg)
-eventAuthField =
-    [ text "Event Auth Field for per-event authorization."
+eventOwnerSelector : List (Html msg)
+eventOwnerSelector =
+    [ text "Event Owner Selector for per-event authorization. "
     , text "Can be used to point to a string field in the event, which "
     , text "is used by Nakadi do decide if an authorized consumer "
     , text "can read a published event. It is optional and "
     , text "if not specified or field is not present/null, all "
     , text "authorized consumers can read the event."
     , newline
-    , bold "The event_auth_field must contain the following fields:"
-    , newline
-    , text "- "
-    , mono "path"
-    , text " path in dot notation of the string field"
-    , text " in an event which will be used to"
-    , text " classify if the consumer is allowed to read the event."
+    , bold "The event_owner_selector must contain the following fields:"
     , newline
     , text "- "
     , mono "type"
-    , text " informational field specifying what type of data the field"
+    , text " Specifies the type of the selector"
+    , newline
+    , text "- "
+    , mono "name"
+    , text " Informational field specifying what type of data the field"
     , text " represents (eg: team/retailers, etc)"
+    , newline
+    , text "- "
+    , mono "value"
+    , text " value in dot notation pointing to a string field"
+    , text " in an event which will be used to"
+    , text " classify if the consumer is allowed to read the event."
     , newline
     , newline
     , bold "Key: "
-    , mono "event_auth_field"
+    , mono "event_owner_selector"
     , bold "optional"
     , newline
-    , man "#definition_EventAuthField"
+    , man "#definition_EventOwnerSelector"
     ]
 
 

--- a/client/Pages/EventTypeDetails/Help.elm
+++ b/client/Pages/EventTypeDetails/Help.elm
@@ -414,6 +414,37 @@ audience =
     ]
 
 
+eventAuthField : List (Html msg)
+eventAuthField =
+    [ text "Event Auth Field for per-event authorization."
+    , text "Can be used to point to a string field in the event, which "
+    , text "is used by Nakadi do decide if an authorized consumer "
+    , text "can read a published event. It is optional and "
+    , text "if not specified or field is not present/null, all "
+    , text "authorized consumers can read the event."
+    , newline
+    , bold "The event_auth_field must contain the following fields:"
+    , newline
+    , text "- "
+    , mono "path"
+    , text " path in dot notation of the string field"
+    , text " in an event which will be used to"
+    , text " classify if the consumer is allowed to read the event."
+    , newline
+    , text "- "
+    , mono "type"
+    , text " informational field specifying what type of data the field"
+    , text " represents (eg: team/retailers, etc)"
+    , newline
+    , newline
+    , bold "Key: "
+    , mono "event_auth_field"
+    , bold "optional"
+    , newline
+    , man "#definition_EventAuthField"
+    ]
+
+
 cleanupPolicy : List (Html msg)
 cleanupPolicy =
     [ text "Event type cleanup policy."

--- a/client/Pages/EventTypeDetails/Help.elm
+++ b/client/Pages/EventTypeDetails/Help.elm
@@ -427,7 +427,7 @@ eventOwnerSelector =
     , newline
     , text "- "
     , mono "type"
-    , text " Specifies the type of the selector"
+    , text " Specifies the type of the selector (can be 'path' or 'static')"
     , newline
     , text "- "
     , mono "name"
@@ -436,7 +436,7 @@ eventOwnerSelector =
     , newline
     , text "- "
     , mono "value"
-    , text " value in dot notation pointing to a string field"
+    , text " Static value or value in dot notation pointing to a string field"
     , text " in an event which will be used to"
     , text " classify if the consumer is allowed to read the event."
     , newline

--- a/client/Pages/EventTypeDetails/Help.elm
+++ b/client/Pages/EventTypeDetails/Help.elm
@@ -1,4 +1,4 @@
-module Pages.EventTypeDetails.Help exposing (audience, authorization, category, cleanupPolicy, cleanupPolicyCompact, compatibilityMode, consumers, consumingQueries, createdAt, defaultStatistic, enrichmentStrategies, envelope, eventType, options, orderingKeyFields, owningApplication, partitionCompactionKeyField, partitionKeyFields, partitionStrategy, partitions, publishers, schema, subscription, updatedAt, eventOwnerSelector)
+module Pages.EventTypeDetails.Help exposing (audience, authorization, category, cleanupPolicy, cleanupPolicyCompact, compatibilityMode, consumers, consumingQueries, createdAt, defaultStatistic, enrichmentStrategies, envelope, eventOwnerSelector, eventType, options, orderingKeyFields, owningApplication, partitionCompactionKeyField, partitionKeyFields, partitionStrategy, partitions, publishers, schema, subscription, updatedAt)
 
 import Config exposing (appPreffix)
 import Helpers.UI exposing (..)

--- a/client/Pages/EventTypeDetails/View.elm
+++ b/client/Pages/EventTypeDetails/View.elm
@@ -31,7 +31,7 @@ import Stores.EventType
         ( EventType
         , EventTypeOptions
         , EventTypeStatistics
-        , EventAuthField
+        , EventOwnerSelector
         , cleanupPolicies
         )
 import Stores.EventTypeSchema
@@ -199,9 +199,9 @@ detailsLayout typeName eventType model =
                             none
                         , infoField "Audience " Help.audience TopRight <|
                             infoStringToText eventType.audience
-                        , infoField "Event Auth Field " Help.eventAuthField TopRight <|
-                            infoEventAuthFieldToText eventType.eventAuthField
-                        , infoField "Created " Help.createdAt |
+                        , infoField "Event Owner Selector " Help.eventOwnerSelector TopRight <|
+                            infoEventOwnerSelectorToText eventType.event_owner_selector
+                        , infoField "Created " Help.createdAt TopRight <|
                             infoDateToText eventType.created_at
                         , infoField "Updated " Help.updatedAt TopRight <|
                             infoDateToText eventType.updated_at
@@ -383,13 +383,14 @@ infoStatisticsToText maybeStatistics =
             infoEmpty
 
 
-infoEventAuthFieldToText : Maybe EventAuthField -> Html Msg
-infoEventAuthFieldToText maybeEventAuthField =
-    case eventAuthField of
-        Just auth_field ->
+infoEventOwnerSelectorToText : Maybe EventOwnerSelector -> Html Msg
+infoEventOwnerSelectorToText maybeEventOwnerSelector =
+    case maybeEventOwnerSelector of
+        Just owner_selector ->
             div []
-                [ infoSubField "Path: " (String.fromString auth_field.path) 
-                , infoSubField "Type: " (String.fromString auth_field.type)
+                [ infoSubField "Type: " (owner_selector.type_) 
+                , infoSubField "Name: " (owner_selector.name)
+                , infoSubField "Value: " (owner_selector.value)
                 ]
         Nothing ->
             infoEmpty

--- a/client/Pages/EventTypeDetails/View.elm
+++ b/client/Pages/EventTypeDetails/View.elm
@@ -31,6 +31,7 @@ import Stores.EventType
         ( EventType
         , EventTypeOptions
         , EventTypeStatistics
+        , EventAuthField
         , cleanupPolicies
         )
 import Stores.EventTypeSchema
@@ -198,7 +199,9 @@ detailsLayout typeName eventType model =
                             none
                         , infoField "Audience " Help.audience TopRight <|
                             infoStringToText eventType.audience
-                        , infoField "Created " Help.createdAt TopRight <|
+                        , infoField "Event Auth Field " Help.eventAuthField TopRight <|
+                            infoEventAuthFieldToText eventType.eventAuthField
+                        , infoField "Created " Help.createdAt |
                             infoDateToText eventType.created_at
                         , infoField "Updated " Help.updatedAt TopRight <|
                             infoDateToText eventType.updated_at
@@ -376,6 +379,18 @@ infoStatisticsToText maybeStatistics =
                 , infoSubField "Write parallelism:" (String.fromInt stat.write_parallelism)
                 ]
 
+        Nothing ->
+            infoEmpty
+
+
+infoEventAuthFieldToText : Maybe EventAuthField -> Html Msg
+infoEventAuthFieldToText maybeEventAuthField =
+    case eventAuthField of
+        Just auth_field ->
+            div []
+                [ infoSubField "Path: " (String.fromString auth_field.path) 
+                , infoSubField "Type: " (String.fromString auth_field.type)
+                ]
         Nothing ->
             infoEmpty
 

--- a/client/Pages/EventTypeDetails/View.elm
+++ b/client/Pages/EventTypeDetails/View.elm
@@ -28,10 +28,10 @@ import Stores.ConsumingQuery exposing (ConsumingQuery)
 import Stores.CursorDistance
 import Stores.EventType
     exposing
-        ( EventType
+        ( EventOwnerSelector
+        , EventType
         , EventTypeOptions
         , EventTypeStatistics
-        , EventOwnerSelector
         , cleanupPolicies
         )
 import Stores.EventTypeSchema
@@ -388,10 +388,11 @@ infoEventOwnerSelectorToText maybeEventOwnerSelector =
     case maybeEventOwnerSelector of
         Just owner_selector ->
             div []
-                [ infoSubField "Type: " (owner_selector.type_) 
-                , infoSubField "Name: " (owner_selector.name)
-                , infoSubField "Value: " (owner_selector.value)
+                [ infoSubField "Type: " owner_selector.type_
+                , infoSubField "Name: " owner_selector.name
+                , infoSubField "Value: " owner_selector.value
                 ]
+
         Nothing ->
             infoEmpty
 

--- a/client/Stores/EventType.elm
+++ b/client/Stores/EventType.elm
@@ -25,6 +25,7 @@ type alias EventType =
     , ordering_key_fields : Maybe (List String)
     , default_statistic : Maybe EventTypeStatistics
     , options : Maybe EventTypeOptions
+    , event_auth_field : Maybe EventAuthField
     , authorization :
         Maybe Authorization
     , --enum delete, compact
@@ -49,6 +50,10 @@ type alias EventTypeOptions =
     { retention_time : Maybe Int
     }
 
+type alias EventAuthField =
+    { path : String
+    , type : String
+    }
 
 type alias Model =
     Helpers.Store.Model EventType
@@ -198,6 +203,7 @@ memberDecoder =
         |> optional "authorization" (nullable Stores.Authorization.collectionDecoder) Nothing
         |> optional "cleanup_policy" string cleanupPolicies.delete
         |> optional "audience" (nullable string) Nothing
+        |> optional "event_auth_field" (nullable eventAuthFieldDecoder) Nothing
         |> optional "created_at" (nullable string) Nothing
         |> optional "updated_at" (nullable string) Nothing
 
@@ -215,3 +221,10 @@ optionsDecoder : Decoder EventTypeOptions
 optionsDecoder =
     succeed EventTypeOptions
         |> optional "retention_time" (nullable int) Nothing
+
+
+eventAuthFieldDecoder : Decoder EventAuthField
+eventAuthFieldDecoder =
+    succeed EventAuthField
+        |> required "path" String
+        |> required "type" String

--- a/client/Stores/EventType.elm
+++ b/client/Stores/EventType.elm
@@ -1,4 +1,4 @@
-module Stores.EventType exposing (EventType, EventTypeOptions, EventTypeStatistics, Model, Msg, allAudiences, allCategories, allCleanupPolicies, allModes, audiences, categories, cleanupPolicies, collectionDecoder, compatibilityModes, config, defaultStatisticDecoder, initialModel, memberDecoder, optionsDecoder, partitionStrategies, EventOwnerSelector, allOwnerSelectorTypes, update, emptyEventOwnerSelector)
+module Stores.EventType exposing (EventOwnerSelector, EventType, EventTypeOptions, EventTypeStatistics, Model, Msg, allAudiences, allCategories, allCleanupPolicies, allModes, allOwnerSelectorTypes, audiences, categories, cleanupPolicies, collectionDecoder, compatibilityModes, config, defaultStatisticDecoder, emptyEventOwnerSelector, initialModel, memberDecoder, optionsDecoder, partitionStrategies, update)
 
 import Config
 import Constants
@@ -56,6 +56,8 @@ type alias EventOwnerSelector =
     , name : String
     , value : String
     }
+
+
 emptyEventOwnerSelector =
     { type_ = ""
     , name = ""
@@ -72,11 +74,13 @@ ownerSelectorTypes =
     , static = "static"
     }
 
+
 allOwnerSelectorTypes : List String
 allOwnerSelectorTypes =
     [ ownerSelectorTypes.path
     , ownerSelectorTypes.static
     ]
+
 
 type alias Model =
     Helpers.Store.Model EventType

--- a/client/Stores/EventType.elm
+++ b/client/Stores/EventType.elm
@@ -1,4 +1,4 @@
-module Stores.EventType exposing (EventType, EventTypeOptions, EventTypeStatistics, Model, Msg, allAudiences, allCategories, allCleanupPolicies, allModes, audiences, categories, cleanupPolicies, collectionDecoder, compatibilityModes, config, defaultStatisticDecoder, initialModel, memberDecoder, optionsDecoder, partitionStrategies, EventOwnerSelector, allOwnerSelectorTypes, update)
+module Stores.EventType exposing (EventType, EventTypeOptions, EventTypeStatistics, Model, Msg, allAudiences, allCategories, allCleanupPolicies, allModes, audiences, categories, cleanupPolicies, collectionDecoder, compatibilityModes, config, defaultStatisticDecoder, initialModel, memberDecoder, optionsDecoder, partitionStrategies, EventOwnerSelector, allOwnerSelectorTypes, update, emptyEventOwnerSelector)
 
 import Config
 import Constants
@@ -55,6 +55,11 @@ type alias EventOwnerSelector =
     { type_ : String
     , name : String
     , value : String
+    }
+emptyEventOwnerSelector =
+    { type_ = ""
+    , name = ""
+    , value = ""
     }
 
 


### PR DESCRIPTION
Add support for field `event_owner_selector` with fields: `type`, `name` and `value`.
(See: https://github.com/zalando/nakadi/pull/1145/files for more details)

It should be possible to update the field, create an event type with the field and view the field in the event type definition.