### PR TITLE
Removes publisher tab from console view.

### DIFF
--- a/client/Pages/EventTypeDetails/Models.elm
+++ b/client/Pages/EventTypeDetails/Models.elm
@@ -49,7 +49,6 @@ initialModel =
 type Tabs
     = SchemaTab
     | PartitionsTab
-    | PublisherTab
     | ConsumerTab
     | AuthTab
     | PublishTab
@@ -140,9 +139,6 @@ stringToTabs str =
 
         "PartitionsTab" ->
             Just PartitionsTab
-
-        "PublisherTab" ->
-            Just PublisherTab
 
         "ConsumerTab" ->
             Just ConsumerTab

--- a/client/Pages/EventTypeDetails/Update.elm
+++ b/client/Pages/EventTypeDetails/Update.elm
@@ -87,9 +87,6 @@ update settings message model =
                         PartitionsTab ->
                             dispatch (PartitionsStoreMsg (loadSubStoreMsg model.name))
 
-                        PublisherTab ->
-                            dispatch LoadPublishers
-
                         ConsumerTab ->
                             Cmd.batch
                                 [ dispatch LoadConsumers

--- a/client/Pages/EventTypeDetails/View.elm
+++ b/client/Pages/EventTypeDetails/View.elm
@@ -1,4 +1,4 @@
-module Pages.EventTypeDetails.View exposing (authTab, consumersPanel, consumersTab, deletePopup, detailsLayout, infoAnyToText, infoDateToText, infoEmpty, infoField, infoListToText, infoOptionsToText, infoStatisticsToText, infoStringToText, infoSubField, issuesTable, partitionsTab, pie, points, renderConsumers, renderPartition, renderPublishers, renderSubscription, schemaTab, severityPanel, subscriptionsPanel, validationPanel, validationSection, view)
+module Pages.EventTypeDetails.View exposing (authTab, consumersPanel, consumersTab, deletePopup, detailsLayout, infoAnyToText, infoDateToText, infoEmpty, infoField, infoListToText, infoOptionsToText, infoStatisticsToText, infoStringToText, infoSubField, issuesTable, partitionsTab, pie, points, renderConsumers, renderPartition, renderSubscription, schemaTab, severityPanel, subscriptionsPanel, validationPanel, validationSection, view)
 
 import Config
 import Constants
@@ -589,17 +589,6 @@ renderPartition totalsStore eventType partition =
                 ]
                 [ text " Inspect events" ]
             ]
-        ]
-
-
-renderPublishers : String -> String -> String -> Stores.Publisher.Publisher -> Html Msg
-renderPublishers name appsInfoUrl usersInfoUrl item =
-    tr [ class "dc-table__tr" ]
-        [ td [ class "dc-table__td" ]
-            [ linkToAppOrUser appsInfoUrl usersInfoUrl item.name ]
-        , td [ class "dc-table__td" ] [ text (String.fromInt item.count) ]
-        , td [ class "dc-table__td" ]
-            []
         ]
 
 

--- a/client/Pages/EventTypeDetails/View.elm
+++ b/client/Pages/EventTypeDetails/View.elm
@@ -1,4 +1,4 @@
-module Pages.EventTypeDetails.View exposing (authTab, consumersPanel, consumersTab, deletePopup, detailsLayout, infoAnyToText, infoDateToText, infoEmpty, infoField, infoListToText, infoOptionsToText, infoStatisticsToText, infoStringToText, infoSubField, issuesTable, partitionsTab, pie, points, publisherTab, renderConsumers, renderPartition, renderPublishers, renderSubscription, schemaTab, severityPanel, subscriptionsPanel, validationPanel, validationSection, view)
+module Pages.EventTypeDetails.View exposing (authTab, consumersPanel, consumersTab, deletePopup, detailsLayout, infoAnyToText, infoDateToText, infoEmpty, infoField, infoListToText, infoOptionsToText, infoStatisticsToText, infoStringToText, infoSubField, issuesTable, partitionsTab, pie, points, renderConsumers, renderPartition, renderPublishers, renderSubscription, schemaTab, severityPanel, subscriptionsPanel, validationPanel, validationSection, view)
 
 import Config
 import Constants
@@ -235,14 +235,6 @@ detailsLayout typeName eventType model =
                                 eventType
                                 pageState.partitionsStore
                                 pageState.totalsStore
-                            )
-                          , ( PublisherTab
-                            , "Publishers"
-                            , publisherTab
-                                eventType
-                                pageState.publishersStore
-                                appsInfoUrl
-                                usersInfoUrl
                             )
                           , ( ConsumerTab
                             , "Consumers"
@@ -596,32 +588,6 @@ renderPartition totalsStore eventType partition =
                 , class "dc-link"
                 ]
                 [ text " Inspect events" ]
-            ]
-        ]
-
-
-publisherTab : EventType -> Stores.Publisher.Model -> String -> String -> Html Msg
-publisherTab eventType publishersStore appsInfoUrl usersInfoUrl =
-    let
-        publishersList =
-            Store.items publishersStore
-
-        count =
-            List.length publishersList
-
-        countStr =
-            pluralCount count "Publisher"
-    in
-    div [ class "dc-card" ]
-        [ span []
-            [ text countStr
-            , helpIcon "Publishers" Help.publishers BottomRight
-            , refreshButton LoadPublishers
-            ]
-        , div [ class "publisher-tab__list" ]
-            [ Helpers.Panel.loadingStatus publishersStore <|
-                grid [ "Publisher application", "Http posts in 4 days", "" ]
-                    (publishersList |> List.map (renderPublishers eventType.name appsInfoUrl usersInfoUrl))
             ]
         ]
 


### PR DESCRIPTION
Tracking publishing has been disabled due to volume
reasons for some time. This stops the tab showing up
in the view.