### PR TITLE
Display a confirmation dialog when updating schemas

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,7 +6,7 @@ installed.
 Also it is better to have [Elm](http://elm-lang.org/) installed globally for an easy use later.
 
 ```bash
-npm install elm@0.19 -g
+npm install elm@latest-0.19.1
 ```
 
 ## Get the source code

--- a/client/Pages/EventTypeCreate/Models.elm
+++ b/client/Pages/EventTypeCreate/Models.elm
@@ -24,6 +24,7 @@ type Operation
     | Update String
     | Clone String
     | CreateQuery
+    | UpdateConfirm String
 
 
 type Field

--- a/client/Pages/EventTypeCreate/View.elm
+++ b/client/Pages/EventTypeCreate/View.elm
@@ -60,6 +60,14 @@ view model =
             Update name ->
                 findEventType name viewFormUpdate
 
+            UpdateConfirm name ->
+                div []
+                    [ div [ class "dc--is-hidden" ]
+                        [ findEventType name viewFormUpdate
+                        ]
+                    , dialog
+                    ]
+
             Clone name ->
                 Helpers.Panel.loadingStatus formModel.partitionsStore <|
                     findEventType name viewFormClone
@@ -67,6 +75,53 @@ view model =
             CreateQuery ->
                 container <|
                     viewQueryForm model
+
+
+dialog : Html Msg
+dialog =
+    div []
+        [ div [ class "dc-overlay" ] []
+        , div [ class "dc-dialog" ]
+            [ div [ class "dc-dialog__content", style "min-width" "600px" ]
+                [ div [ class "dc-dialog__body" ]
+                    [ div [ class "dc-dialog__close" ]
+                        [ i
+                            [ onClick Reset
+                            , class "dc-icon dc-icon--close dc-icon--interactive dc-dialog__close__icon"
+                            ]
+                            []
+                        ]
+                    , h3 [ class "dc-dialog__title" ]
+                        [ text "Schema change confirmation" ]
+                    , div [ class "dc-msg dc-msg--error" ]
+                        [ div [ class "dc-msg__inner" ]
+                            [ div [ class "dc-msg__icon-frame" ]
+                                [ i [ class "dc-icon dc-msg__icon dc-icon--warning" ] []
+                                ]
+                            , div [ class "dc-msg__bd" ]
+                                [ h1 [ class "dc-msg__title blinking" ] [ text "Warning! Dangerous Action!" ]
+                                , p [ class "dc-msg__text" ]
+                                    [ text
+                                        ("Schema changes cannot be undone and may have undesirable side effects "
+                                            ++ "such as instructing Nakadi to refuse the ingestion of soon to become "
+                                            ++ "incompatible events."
+                                        )
+                                    , text " Please make sure to validate this change in a test environment first."
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                , div [ class "dc-dialog__actions" ]
+                    [ button
+                        [ onClick Submit
+                        , class "dc-btn dc-btn--primary"
+                        ]
+                        [ text "Confirm" ]
+                    ]
+                ]
+            ]
+        ]
 
 
 viewFormCreate : AppModel -> Html Msg

--- a/package-lock.json
+++ b/package-lock.json
@@ -7322,6 +7322,12 @@
         }
       }
     },
+    "natives": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
+      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
+      "dev": true
+    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
@@ -10027,10 +10033,13 @@
           },
           "dependencies": {
             "graceful-fs": {
-              "version": "4.2.3",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-              "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-              "dev": true
+              "version": "3.0.12",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.12.tgz",
+              "integrity": "sha512-J55gaCS4iTTJfTXIxSVw3EMQckcqkpdRv3IR7gu6sq0+tbC363Zx6KH/SEwXASK9JRbhyZmVjJEVJIOxYsB3Qg==",
+              "dev": true,
+              "requires": {
+                "natives": "^1.1.3"
+              }
             }
           }
         },


### PR DESCRIPTION
Users often change schemas without fully understading the consequences. This leads to multiple incidents and increased support effort in order to work around and amend such mistakes.

We consider that displaying a message asking for confirmation and alerting users to the potentially dangerous actions they are about to perform could have a positive impact.

The dialog is only shown when there are changes in the schema. Otherwise it continues to work as before.

![Screen Shot 2020-05-26 at 5 46 46 PM](https://user-images.githubusercontent.com/344648/82921773-0e6b6580-9f79-11ea-9e9f-e16f45f6915b.png)
