### PR TITLE
Correctly display error messages returned by the server

### DIFF
--- a/client/Pages/EventTypeCreate/Update.elm
+++ b/client/Pages/EventTypeCreate/Update.elm
@@ -91,7 +91,10 @@ update message model eventTypeStore user =
                     ( Store.onFetchStart model, submitQueryCreate model )
 
                 UpdateConfirm name ->
-                    ( Store.onFetchStart model, submitUpdate model )
+                    let
+                        m = Store.onFetchStart model
+                    in
+                    ( { m | operation = Update name }, submitUpdate model )
 
         Reset ->
             let


### PR DESCRIPTION
When introducing the alert message, a new operation was added UpdateConfirm, which causes the warning message to be displayed and the form to be hidden.

Once the form is submitted, if the server answers with an error, 422 in case of invalid change, the error message would not be displayed to the user, as this message is only displayed in the `Update` operation and not in the `UpdateConfirm`.

This change switched back the state of the page to `Update` after confirming the dialog and submitting it. Then the message is again correctly displayed at the bottom of the page as before.