### PR TITLE
Nakadi SQL query output event type monitoring link

### DIFF
--- a/client/Pages/EventTypeDetails/View.elm
+++ b/client/Pages/EventTypeDetails/View.elm
@@ -100,6 +100,13 @@ detailsLayout typeName eventType model =
         isQueryOutput =
             showNakadiSql && isSuccess pageState.loadQueryResponse
 
+        eventTypeMonitoringLink =
+            if isQueryOutput then
+                replace "{query}" eventType.name settings.queryMonitoringUrl
+
+            else
+                replace "{et}" eventType.name model.userStore.user.settings.eventTypeMonitoringUrl
+
         tab =
             pageState.tab
 
@@ -156,7 +163,7 @@ detailsLayout typeName eventType model =
                         [ title "Monitoring Graphs"
                         , class "icon-link dc-icon dc-icon--interactive"
                         , target "_blank"
-                        , href <| replace "{et}" eventType.name model.userStore.user.settings.eventTypeMonitoringUrl
+                        , href <| eventTypeMonitoringLink
                         ]
                         [ i [ class "icon icon--chart" ] [] ]
                     , starIcon OutAddToFavorite OutRemoveFromFavorite model.starredEventTypesStore eventType.name


### PR DESCRIPTION
When clicking the monitoring link for an event type that is the output
of a Nakadi SQL, users were redirected to a dashboard that wasn't
displaying any data. That's because for such event types a different
dashboard would be better suited, as the source of data has to be a
different one (not Nakadi but Nakadi SQL).