### PR TITLE
Add read_from option to query creation

### DIFF
--- a/client/Pages/EventTypeCreate/Models.elm
+++ b/client/Pages/EventTypeCreate/Models.elm
@@ -44,6 +44,7 @@ type Field
     | FieldEventOwnerSelectorName
     | FieldEventOwnerSelectorValue
     | FieldCleanupPolicy
+    | FieldReadFrom
     | FieldSql
     | FieldPartitionCompactionKeyField
 

--- a/client/Pages/EventTypeCreate/Query.elm
+++ b/client/Pages/EventTypeCreate/Query.elm
@@ -21,6 +21,7 @@ import Models exposing (AppModel)
 import Pages.EventTypeCreate.Messages exposing (..)
 import Pages.EventTypeCreate.Models exposing (..)
 import Pages.EventTypeDetails.Help as Help
+import Pages.SubscriptionCreate.Models exposing (readFrom)
 import Stores.Authorization exposing (Authorization)
 import Stores.EventType exposing (EventType, allAudiences, categories, cleanupPolicies)
 
@@ -68,6 +69,17 @@ viewQueryForm model =
                 Enabled
                 [ cleanupPolicies.compact
                 , cleanupPolicies.delete
+                ]
+            , selectInput formModel
+                FieldReadFrom
+                OnInput
+                "Read from"
+                ""
+                Help.readFrom
+                Required
+                Enabled
+                [ readFrom.end
+                , readFrom.begin
                 ]
             , selectInput formModel
                 FieldEnvelope
@@ -260,6 +272,7 @@ encodeQuery model =
                     , ( "owning_application", asString FieldOwningApplication )
                     , ( "category", asString FieldCategory )
                     , ( "cleanup_policy", asString FieldCleanupPolicy )
+                    , ( "read_from", asString FieldReadFrom )
                     , ( "retention_time", daysToRetentionTimeJson model.values )
                     , ( "partition_compaction_key_field", asString FieldPartitionCompactionKeyField )
                     , ( "ordering_key_fields", orderingKeyFields )

--- a/client/Pages/EventTypeDetails/Help.elm
+++ b/client/Pages/EventTypeDetails/Help.elm
@@ -1,4 +1,4 @@
-module Pages.EventTypeDetails.Help exposing (audience, authorization, category, cleanupPolicy, cleanupPolicyCompact, compatibilityMode, consumers, consumingQueries, createdAt, defaultStatistic, enrichmentStrategies, envelope, eventOwnerSelector, eventType, options, orderingKeyFields, owningApplication, partitionCompactionKeyField, partitionKeyFields, partitionStrategy, partitions, schema, subscription, updatedAt)
+module Pages.EventTypeDetails.Help exposing (audience, authorization, category, cleanupPolicy, cleanupPolicyCompact, compatibilityMode, consumers, consumingQueries, createdAt, defaultStatistic, enrichmentStrategies, envelope, eventOwnerSelector, eventType, options, orderingKeyFields, owningApplication, partitionCompactionKeyField, partitionKeyFields, partitionStrategy, partitions, readFrom, schema, subscription, updatedAt)
 
 import Config exposing (appPreffix)
 import Helpers.UI exposing (..)
@@ -467,6 +467,27 @@ cleanupPolicy =
     , mono "delete"
     , newline
     , man "#definition_EventType*cleanup_policy"
+    ]
+
+
+readFrom : List (Html msg)
+readFrom =
+    [ text "This field indicates where the query should start from."
+    , newline
+    , bold "Currently supported values:"
+    , newline
+    , text "- "
+    , mono "begin"
+    , text " read from the oldest available event. This means that once the query starts, it processes all available"
+    , text " events in the input event types. When creating queries with JOINs, this is highly likely to be the option"
+    , text " that matches most users expectations."
+    , newline
+    , text "- "
+    , mono "end"
+    , text " read from the most recent offset. This means that this query processes only events sent after its"
+    , text " creation and "
+    , bold "does not"
+    , text " processes all the events within the retention time of the input event type."
     ]
 
 

--- a/client/Stores/EventType.elm
+++ b/client/Stores/EventType.elm
@@ -178,6 +178,16 @@ cleanupPolicies =
     }
 
 
+readFrom :
+    { end : String
+    , begin : String
+    }
+readFrom =
+    { end = "end"
+    , begin = "begin"
+    }
+
+
 allCleanupPolicies : List String
 allCleanupPolicies =
     [ cleanupPolicies.delete


### PR DESCRIPTION

![Screen Shot 2020-07-13 at 5 20 11 PM](https://user-images.githubusercontent.com/344648/87323011-79bfc580-c52e-11ea-9ec5-96c95fecf91d.png)


When creating a new query, Nakadi SQL would process the entire backlog
of events sitting in the input event types. This lead to a spike in
load and the production of potentially a lot of events.

The decision to process all the events was made when we only had
queries for which this is the only sensible choice, namely FULL OUTER
JOINs.

In a full outer join, not having the complete state of the input event
types makes little sense.

But since then, a lot has changed and currently the most common type
of query are stateless queries, meaning filters and projections. For a
significant amount of users, producing events retroactively is not the
expected behaviour and is the most cost inneficient, thus this field
is introduced with default to 'end'.

There is a chance users might pick 'end' without first understanding
its implications or simply overlooking and later on having their
queries not producing events. But parsing the query to identify if the
input event type is a log compacted event type would be significantly
more complex so we trust users to make a sensible choice.