### PR TITLE
Read from is not a property of the output event type

### DIFF
--- a/client/Pages/EventTypeCreate/Query.elm
+++ b/client/Pages/EventTypeCreate/Query.elm
@@ -272,7 +272,6 @@ encodeQuery model =
                     , ( "owning_application", asString FieldOwningApplication )
                     , ( "category", asString FieldCategory )
                     , ( "cleanup_policy", asString FieldCleanupPolicy )
-                    , ( "read_from", asString FieldReadFrom )
                     , ( "retention_time", daysToRetentionTimeJson model.values )
                     , ( "partition_compaction_key_field", asString FieldPartitionCompactionKeyField )
                     , ( "ordering_key_fields", orderingKeyFields )
@@ -282,6 +281,7 @@ encodeQuery model =
             , ( "sql", asString FieldSql )
             , ( "authorization", auth )
             , ( "envelope", asBool FieldEnvelope )
+            , ( "read_from", asString FieldReadFrom )
             ]
     in
     Json.object fields


### PR DESCRIPTION
The field was passed in the wrong place and as the API is lenient, it
accepted the request without informing the calling application that it
was passing something in the wrong place.

I think we should review this lenience as it allows for typos to go undetected.