### PR TITLE
Missing default value

### DIFF
--- a/client/Pages/EventTypeCreate/Models.elm
+++ b/client/Pages/EventTypeCreate/Models.elm
@@ -111,6 +111,7 @@ defaultValues =
     , ( FieldEventOwnerSelectorValue, "" )
     , ( FieldCleanupPolicy, cleanupPolicies.delete )
     , ( FieldPartitionCompactionKeyField, emptyString )
+    , ( FieldReadFrom, "end")
     ]
         |> toValuesDict
 


### PR DESCRIPTION
This was causing an issue when creating queries that would force the
user to select the `read_from` in the form even though it was already
displaying as selected. That's because of how forms work in this app,
they are not extracted from a readl html form.