### PR TITLE
Allow numbers after dots in event type name

### DIFF
--- a/client/Pages/EventTypeCreate/Update.elm
+++ b/client/Pages/EventTypeCreate/Update.elm
@@ -338,7 +338,7 @@ checkNameFormat model dict =
             model.values |> getValue FieldName |> String.trim
 
         pattern =
-            Helpers.Regex.fromString "^[a-zA-Z][-0-9a-zA-Z_]*(\\.[a-zA-Z][-0-9a-zA-Z_]*)*$"
+            Helpers.Regex.fromString "^[a-zA-Z][-0-9a-zA-Z_]*(\\.[0-9a-zA-Z][-0-9a-zA-Z_]*)*$"
     in
     if Regex.contains pattern name then
         dict


### PR DESCRIPTION
Allow number after dots in event type name (same as https://nakadi.io/manual.html#definition_EventType*name)