### PR TITLE
Allow cleanup policy change for delete to compact_delete

### DIFF
--- a/client/Pages/EventTypeCreate/View.elm
+++ b/client/Pages/EventTypeCreate/View.elm
@@ -170,7 +170,12 @@ viewFormUpdate model originalEventType =
                 [ originalEventType.category ]
 
         cleanupPoliciesOptions =
-            [ originalEventType.cleanup_policy ]
+            if originalEventType.cleanup_policy == cleanupPolicies.delete then
+                [ cleanupPolicies.delete
+                , cleanupPolicies.compact_delete
+                ]
+            else
+                [ originalEventType.cleanup_policy ]
     in
     viewForm model
         { nameEditing = Disabled

--- a/client/Pages/EventTypeCreate/View.elm
+++ b/client/Pages/EventTypeCreate/View.elm
@@ -174,6 +174,7 @@ viewFormUpdate model originalEventType =
                 [ cleanupPolicies.delete
                 , cleanupPolicies.compact_delete
                 ]
+
             else
                 [ originalEventType.cleanup_policy ]
     in


### PR DESCRIPTION
Add option to change cleanup policy from `delete` to `compact_and_delete` while updating an event type. 

Related Nakadi change: https://github.com/zalando/nakadi/pull/1235