### PR TITLE
Change the documentation example for partition_compaction_key_field

### DIFF
--- a/client/Pages/EventTypeCreate/Query.elm
+++ b/client/Pages/EventTypeCreate/Query.elm
@@ -101,7 +101,7 @@ viewQueryForm model =
                     FieldPartitionCompactionKeyField
                     OnInput
                     "Partition Compaction Key Field"
-                    "Example: metadata.partition_compaction_key"
+                    "Example: payload.metadata.partition_compaction_key"
                     "Field to be used as partition_compaction_key"
                     Help.partitionCompactionKeyField
                     Required

--- a/client/Pages/EventTypeDetails/Help.elm
+++ b/client/Pages/EventTypeDetails/Help.elm
@@ -578,7 +578,7 @@ partitionCompactionKeyField =
     [ text "This field is useful & necessary in case the output event-type is log-compacted"
     , text " The value in the field specified is used as the partition_compaction_key for the output"
     , text " event type. Thus, this field should be non-nullable and of type string. In case of join queries,"
-    , text " this field should be set to metadata.partition_compaction_key and partition_compaction_key from"
+    , text " this field should be set to <table_alias>.metadata.partition_compaction_key and partition_compaction_key from"
     , text " one of the joined events is used as the key for the output event type."
     , newline
     , bold "This field is mandatory only if input event type is non log-compacted and output event type is compacted"


### PR DESCRIPTION
Change the example for `partition_compaction_key_field` to include the <payload> table alias. (the table alias in example query is `payload`)