### PR TITLE
Change default owning application for event type, query create to an empty value

### DIFF
--- a/client/Pages/EventTypeCreate/Models.elm
+++ b/client/Pages/EventTypeCreate/Models.elm
@@ -1,4 +1,4 @@
-module Pages.EventTypeCreate.Models exposing (Field(..), Model, Operation(..), defaultApplication, defaultRetentionDays, defaultSchema, defaultSql, defaultValues, initialModel, loadValues)
+module Pages.EventTypeCreate.Models exposing (Field(..), Model, Operation(..), defaultRetentionDays, defaultSchema, defaultSql, defaultValues, initialModel, loadValues)
 
 import Config exposing (appPreffix)
 import Constants exposing (emptyString)
@@ -86,15 +86,10 @@ defaultRetentionDays =
     1
 
 
-defaultApplication : String
-defaultApplication =
-    appPreffix ++ "nakadi-ui-elm"
-
-
 defaultValues : ValuesDict
 defaultValues =
     [ ( FieldName, emptyString )
-    , ( FieldOwningApplication, defaultApplication )
+    , ( FieldOwningApplication, "" )
     , ( FieldCategory, categories.business )
     , ( FieldPartitionStrategy, partitionStrategies.random )
     , ( FieldPartitionsNumber, "1" )

--- a/client/Pages/SubscriptionCreate/Models.elm
+++ b/client/Pages/SubscriptionCreate/Models.elm
@@ -1,4 +1,4 @@
-module Pages.SubscriptionCreate.Models exposing (Field(..), Model, Operation(..), allReadFrom, cloneValues, copyValues, defaultApplication, defaultValues, initialModel, readFrom)
+module Pages.SubscriptionCreate.Models exposing (Field(..), Model, Operation(..), allReadFrom, cloneValues, copyValues, defaultValues, initialModel, readFrom)
 
 import Config exposing (appPreffix)
 import Constants exposing (emptyString)
@@ -76,15 +76,10 @@ allReadFrom =
     ]
 
 
-defaultApplication : String
-defaultApplication =
-    appPreffix ++ "nakadi-ui-elm"
-
-
 defaultValues : ValuesDict
 defaultValues =
     [ ( FieldConsumerGroup, emptyString )
-    , ( FieldOwningApplication, defaultApplication )
+    , ( FieldOwningApplication, emptyString )
     , ( FieldReadFrom, readFrom.end )
     , ( FieldEventTypes, emptyString )
     ]

--- a/tests/end2end/createEtForm.spec.js
+++ b/tests/end2end/createEtForm.spec.js
@@ -23,7 +23,11 @@ describe('Create Event type form', function() {
         })
         .selectByValue("#eventTypeCreateFormFieldAudience", 'component-internal')
         .isEnabled('button=Create Event Type').then(function(enabled) {
-            expect(enabled).toBeTruthy('Submit btn should be enabled if name is set')
+            expect(enabled).toBeFalsy('Submit btn should be disabled if owning application is not set')
+        })
+        .setValue('#eventTypeCreateFormFieldOwningApplication', 'some-owning-app')
+        .isEnabled('button=Create Event Type').then(function(enabled) {
+            expect(enabled).toBeTruthy('Submit btn should be enabled if name and owning app are set')
         })
         .click('button=Create Event Type')
         .waitForVisible(`span*=${eventTypeName}`, 10000)

--- a/tests/end2end/createEtForm.spec.js
+++ b/tests/end2end/createEtForm.spec.js
@@ -25,7 +25,7 @@ describe('Create Event type form', function() {
         .isEnabled('button=Create Event Type').then(function(enabled) {
             expect(enabled).toBeFalsy('Submit btn should be disabled if owning application is not set')
         })
-        .setValue('#eventTypeCreateFormFieldOwningApplication', 'some-owning-app')
+        .setValue('#eventTypeCreateFormFieldOwningApplication', 'stups_nakadi-ui-elm')
         .isEnabled('button=Create Event Type').then(function(enabled) {
             expect(enabled).toBeTruthy('Submit btn should be enabled if name and owning app are set')
         })

--- a/tests/end2end/createSubscriptionForm.spec.js
+++ b/tests/end2end/createSubscriptionForm.spec.js
@@ -21,6 +21,7 @@ describe('Create Subscription form', function() {
         })
         .setValue('#subscriptionCreateFormFieldConsumerGroup', 'test-group')
         .setValue('#subscriptionCreateFormFieldEventTypes', eventTypeName)
+        .setValue('#subscriptionCreateFormFieldOwningApplication', 'someowningapplication')
         .isEnabled('button=Create Subscription').then(function(enabled) {
             expect(enabled).toBeTruthy('Submit btn should be enabled if name is set')
         })

--- a/tests/end2end/createSubscriptionForm.spec.js
+++ b/tests/end2end/createSubscriptionForm.spec.js
@@ -21,7 +21,7 @@ describe('Create Subscription form', function() {
         })
         .setValue('#subscriptionCreateFormFieldConsumerGroup', 'test-group')
         .setValue('#subscriptionCreateFormFieldEventTypes', eventTypeName)
-        .setValue('#subscriptionCreateFormFieldOwningApplication', 'someowningapplication')
+        .setValue('#subscriptionCreateFormFieldOwningApplication', 'stups_nakadi-ui-elm')
         .isEnabled('button=Create Subscription').then(function(enabled) {
             expect(enabled).toBeTruthy('Submit btn should be enabled if name is set')
         })


### PR DESCRIPTION
There is no meaning in having default value that users have to constantly override.