### PR TITLE
[TEST] Disable nodejs overlay to test apt update

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -1,7 +1,7 @@
 version: "2017-09-20"
 pipeline:
   - id: build
-    overlay: ci/nodejs
+    #overlay: ci/nodejs
     cache:
       paths:
         - ~/.npm


### PR DESCRIPTION
It started to fail all of a sudden today with the following error:
```
W: The repository 'https://deb.nodesource.com/node_10.x xenial Release' does not have a Release file.
E: Failed to fetch https://deb.nodesource.com/node_10.x/dists/xenial/main/source/Sources  server certificate verification failed. CAfile: /etc/ssl/certs/ca-certificates.crt CRLfile: none
E: Some index files failed to download. They have been ignored, or old ones
used instead.
```